### PR TITLE
xstate-5-beta

### DIFF
--- a/examples/01_typescript/src/App.tsx
+++ b/examples/01_typescript/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Provider, useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
-import { atomWithMachine } from 'jotai-xstate'
+import { atomWithActor } from 'jotai-xstate'
 import { assign, createMachine } from 'xstate'
 
 const createEditableMachine = (value: string) =>
@@ -23,7 +23,7 @@ const createEditableMachine = (value: string) =>
           commit: {
             target: 'reading',
             actions: assign({
-              value: (_, { value }) => value,
+              value: ({ event }) => event.value,
             }),
           },
         },
@@ -32,12 +32,12 @@ const createEditableMachine = (value: string) =>
   })
 
 const defaultTextAtom = atom('edit me')
-const editableMachineAtom = atomWithMachine((get) =>
+const editableMachineAtom = atomWithActor((get) =>
   createEditableMachine(get(defaultTextAtom))
 )
 
 const Toggle = () => {
-  const [state, send] = useAtom(editableMachineAtom)
+  const [{ state }, send] = useAtom(editableMachineAtom)
 
   return (
     <div>
@@ -54,7 +54,7 @@ const Toggle = () => {
               send({ type: 'commit', value: e.currentTarget.value })
             }
             if (e.key === 'Escape') {
-              send('cancel')
+              send({ type: 'cancel' })
             }
           }}
         />

--- a/examples/01_typescript/src/SubExample.tsx
+++ b/examples/01_typescript/src/SubExample.tsx
@@ -22,6 +22,9 @@ const childMachine = createMachine({
       ],
     },
   },
+  types: {} as {
+    events: { type: 'child.start' }
+  },
 })
 
 const appMachine = createMachine({
@@ -64,8 +67,8 @@ const appMachine = createMachine({
 
 const appMachineAtom = atomWithActor(appMachine)
 
-const childMachineAtom = atomWithActorSubscription<typeof childMachine>(
-  (get) => get(appMachineAtom).actorRef
+const childMachineAtom = atomWithActorSubscription<typeof childMachine>((get) =>
+  get(appMachineAtom).actorRef.system.get('childMachine')
 )
 
 export default function Page() {

--- a/examples/01_typescript/src/SubExample.tsx
+++ b/examples/01_typescript/src/SubExample.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { useAtom } from 'jotai/react'
+import { atomWithActor, atomWithActorSubscription } from 'jotai-xstate'
+import { createMachine } from 'xstate'
+
+const childMachine = createMachine({
+  id: 'ChildMachine',
+  initial: 'IDLE',
+  states: {
+    IDLE: {
+      on: {
+        'child.start': [
+          {
+            target: 'RUNNING',
+          },
+        ],
+      },
+    },
+    RUNNING: {
+      entry: [
+        ({ context, event }) => console.log('CHILD RUNNING', context, event),
+      ],
+    },
+  },
+})
+
+const appMachine = createMachine({
+  id: 'AppMachine',
+  initial: 'IDLE',
+  invoke: {
+    id: 'childMachine',
+    systemId: 'childMachine',
+    src: childMachine,
+  },
+  states: {
+    IDLE: {
+      on: {
+        'app.start': [
+          {
+            target: 'RUNNING',
+            guard: () => typeof window !== 'undefined',
+          },
+          {
+            target: 'SERVER',
+            guard: () => typeof window === 'undefined',
+          },
+        ],
+      },
+    },
+    RUNNING: {
+      entry: [
+        ({ context, event }) =>
+          console.log('RUNNING ON CLIENT', context, event),
+      ],
+    },
+    SERVER: {
+      entry: [
+        ({ context, event }) =>
+          console.log('RUNNING ON SERVER', context, event),
+      ],
+    },
+  },
+})
+
+const appMachineAtom = atomWithActor(appMachine)
+
+const childMachineAtom = atomWithActorSubscription<typeof childMachine>(
+  (get) => get(appMachineAtom).actorRef
+)
+
+export default function Page() {
+  const [{ state }, send] = useAtom(appMachineAtom)
+  const [{ state: childState }, childSend] = useAtom(childMachineAtom)
+
+  return (
+    <div>
+      <h1>App State: {state.value.toString()}</h1>
+      <h2>Child State: {childState.value.toString()}</h2>
+      <button onClick={() => send({ type: 'app.start' })}>Start App</button>
+      <button onClick={() => childSend({ type: 'child.start' })}>
+        Start Child
+      </button>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1",
-    "xstate": "^4.35.4"
+    "xstate": "^5.0.0-beta.14"
   },
   "peerDependencies": {
     "jotai": ">=1.11.0",

--- a/src/atom-with-actor-subscription.ts
+++ b/src/atom-with-actor-subscription.ts
@@ -1,0 +1,116 @@
+import { type Getter, atom } from 'jotai'
+import {
+  type ActorRefFrom,
+  type AnyStateMachine,
+  type EventFromLogic,
+  type Interpreter,
+  type SnapshotFrom,
+} from 'xstate'
+import { isGetter } from './utils'
+
+export function atomWithActorSubscription<
+  TMachine extends AnyStateMachine = AnyStateMachine,
+  Parent extends ActorRefFrom<AnyStateMachine> = ActorRefFrom<AnyStateMachine>
+>(
+  systemId: string | ((get: Getter) => string),
+  getMachine: Parent | ((get: Getter) => Parent)
+) {
+  const providedMachineAtom = atom<null | {
+    machine: Parent
+    actor: Interpreter<TMachine, EventFromLogic<TMachine>>
+  }>(null)
+
+  const cachedMachineStateAtom = atom<SnapshotFrom<TMachine> | null>(null)
+  if (process.env['NODE_ENV'] !== 'production') {
+    cachedMachineStateAtom.debugPrivate = true
+  }
+
+  const machineOperatorAtom = atom(
+    (get) => {
+      const interpretedMachine = get(providedMachineAtom)
+      if (interpretedMachine) return interpretedMachine
+
+      let initializing = true
+      const safeGet: typeof get = (...args) => {
+        if (initializing) {
+          return get(...args)
+        }
+        throw new Error('get not allowed after initialization')
+      }
+      const id = isGetter(systemId) ? systemId(safeGet) : systemId
+      const machine = isGetter(getMachine) ? getMachine(safeGet) : getMachine
+
+      const foundActor = machine.system?.get(id)
+      if (!foundActor) {
+        throw new Error(`No actor found with id ${id}`)
+      }
+
+      initializing = false
+
+      return {
+        machine,
+        actor: foundActor as Interpreter<TMachine, EventFromLogic<TMachine>>,
+      }
+    },
+    (get, set) => {
+      if (get(providedMachineAtom) === null) return
+      set(providedMachineAtom, get(machineOperatorAtom))
+    }
+  )
+  machineOperatorAtom.onMount = (commit) => {
+    commit()
+  }
+
+  const actorOrchestratorAtom = atom(
+    (get) => get(machineOperatorAtom).actor,
+    (get, set, registerCleanup: (cleanup: () => void) => void) => {
+      const { actor } = get(machineOperatorAtom)
+      const subscription = actor.subscribe((nextState) => {
+        set(cachedMachineStateAtom, nextState)
+      })
+      registerCleanup(() => {
+        subscription.unsubscribe()
+      })
+    }
+  )
+  actorOrchestratorAtom.onMount = (initialize) => {
+    let unSubscribe: (() => void) | undefined | false
+
+    initialize((cleanup) => {
+      if (unSubscribe === false) {
+        cleanup()
+      } else {
+        unSubscribe = cleanup
+      }
+    })
+
+    return () => {
+      if (unSubscribe) {
+        unSubscribe()
+      }
+      unSubscribe = false
+    }
+  }
+
+  const actorStateAtom = atom(
+    (get) => {
+      const state =
+        get(cachedMachineStateAtom) ??
+        (get(actorOrchestratorAtom).getSnapshot() as SnapshotFrom<TMachine>)
+      const actorRef = get(actorOrchestratorAtom)
+      return { state, actorRef }
+    },
+    (
+      get,
+      set,
+      action:
+        | EventFromLogic<TMachine>
+        | ({ type: string } & Record<string, unknown>)
+    ) => {
+      const actor = get(actorOrchestratorAtom)
+      actor.send(action as EventFromLogic<TMachine>)
+    }
+  )
+
+  return actorStateAtom
+}

--- a/src/atom-with-actor-subscription.ts
+++ b/src/atom-with-actor-subscription.ts
@@ -11,7 +11,7 @@ export function atomWithActorSubscription<
   TMachine extends AnyStateMachine = AnyStateMachine,
   TActorRef extends Interpreter<
     TMachine,
-    EventFromLogic<AnyStateMachine>
+    EventFromLogic<TMachine>
   > = Interpreter<TMachine, EventFromLogic<TMachine>>,
   TSend extends EventFromLogic<TMachine> = EventFromLogic<TMachine>
 >(getActor: TActorRef | ((get: Getter) => TActorRef)) {

--- a/src/atom-with-actor-subscription.ts
+++ b/src/atom-with-actor-subscription.ts
@@ -100,13 +100,7 @@ export function atomWithActorSubscription<
       const actorRef = get(actorOrchestratorAtom)
       return { state, actorRef }
     },
-    (
-      get,
-      set,
-      action:
-        | EventFromLogic<TMachine>
-        | ({ type: string } & Record<string, unknown>)
-    ) => {
+    (get, set, action: EventFromLogic<TMachine>) => {
       const actor = get(actorOrchestratorAtom)
       actor.send(action as EventFromLogic<TMachine>)
     }

--- a/src/atom-with-actor.ts
+++ b/src/atom-with-actor.ts
@@ -1,4 +1,4 @@
-import { type Getter, type WritableAtom, atom } from 'jotai'
+import { type Getter, atom } from 'jotai'
 import {
   type AnyStateMachine,
   type EventFromLogic,
@@ -10,7 +10,10 @@ import {
 } from 'xstate'
 import { isGetter } from './utils'
 
-export function atomWithActor<TMachine extends AnyStateMachine>(
+export function atomWithActor<
+  TMachine extends AnyStateMachine,
+  TSend extends EventFromLogic<TMachine> = EventFromLogic<TMachine>
+>(
   getMachine: TMachine | ((get: Getter) => TMachine),
   getOptions?:
     | Partial<InterpreterOptions<TMachine>>
@@ -112,9 +115,9 @@ export function atomWithActor<TMachine extends AnyStateMachine>(
       const actorRef = get(actorOrchestratorAtom)
       return { state, actorRef }
     },
-    (get, set, action: EventFromLogic<TMachine>) => {
+    (get, set, action: TSend) => {
       const actor = get(actorOrchestratorAtom)
-      actor.send(action as EventFromLogic<TMachine>)
+      actor.send(action)
     }
   )
 

--- a/src/atom-with-actor.ts
+++ b/src/atom-with-actor.ts
@@ -1,0 +1,138 @@
+import { type Getter, atom } from 'jotai'
+import {
+  type AnyStateMachine,
+  type EventFromLogic,
+  type Interpreter,
+  type InterpreterOptions,
+  InterpreterStatus,
+  type SnapshotFrom,
+  interpret,
+} from 'xstate'
+import { isGetter } from './utils'
+
+export function atomWithActor<TMachine extends AnyStateMachine>(
+  getMachine: TMachine | ((get: Getter) => TMachine),
+  getOptions?:
+    | Partial<InterpreterOptions<TMachine>>
+    | ((get: Getter) => Partial<InterpreterOptions<TMachine>>)
+) {
+  const interpretedMachineAtom = atom<null | {
+    machine: TMachine
+    actor: Interpreter<TMachine, EventFromLogic<TMachine>>
+  }>(null)
+
+  const cachedMachineStateAtom = atom<SnapshotFrom<TMachine> | null>(null)
+  if (process.env['NODE_ENV'] !== 'production') {
+    cachedMachineStateAtom.debugPrivate = true
+  }
+
+  const machineOperatorAtom = atom(
+    (get) => {
+      const interpretedMachine = get(interpretedMachineAtom)
+      if (interpretedMachine) return interpretedMachine
+
+      let initializing = true
+      const safeGet: typeof get = (...args) => {
+        if (initializing) {
+          return get(...args)
+        }
+        throw new Error('get not allowed after initialization')
+      }
+      const machine = isGetter(getMachine) ? getMachine(safeGet) : getMachine
+      const options = isGetter(getOptions) ? getOptions(safeGet) : getOptions
+      if (options?.systemId && options?.parent && options.parent.system) {
+        const existingActor = options.parent.system?.get(options.systemId)
+        if (existingActor) {
+          return {
+            machine,
+            actor: existingActor as Interpreter<
+              TMachine,
+              EventFromLogic<TMachine>
+            >,
+          }
+        }
+      }
+
+      const actor = interpret(machine, options)
+      initializing = false
+      return { machine, actor }
+    },
+    (get, set) => {
+      if (get(interpretedMachineAtom) === null) return
+      set(interpretedMachineAtom, get(machineOperatorAtom))
+    }
+  )
+  machineOperatorAtom.onMount = (commit) => {
+    commit()
+  }
+
+  const actorOrchestratorAtom = atom(
+    (get) => get(machineOperatorAtom).actor,
+    (get, set, registerCleanup: (cleanup: () => void) => void) => {
+      const { actor } = get(machineOperatorAtom)
+      const subscription = actor.subscribe((nextState) => {
+        set(cachedMachineStateAtom, nextState)
+      })
+      actor.start()
+      registerCleanup(() => {
+        const { actor } = get(machineOperatorAtom)
+        subscription.unsubscribe()
+        if (!actor._parent) {
+          actor.stop()
+          actor.status = InterpreterStatus.NotStarted
+          ;(actor as any)._initState()
+        }
+      })
+    }
+  )
+  actorOrchestratorAtom.onMount = (initialize) => {
+    let unSubscribe: (() => void) | undefined | false
+
+    initialize((cleanup) => {
+      if (unSubscribe === false) {
+        cleanup()
+      } else {
+        unSubscribe = cleanup
+      }
+    })
+
+    return () => {
+      if (unSubscribe) {
+        unSubscribe()
+      }
+      unSubscribe = false
+    }
+  }
+
+  const actorStateAtom = atom(
+    (get) => {
+      const state =
+        get(cachedMachineStateAtom) ??
+        (get(actorOrchestratorAtom).getSnapshot() as SnapshotFrom<TMachine>)
+      const actorRef = get(actorOrchestratorAtom)
+      return { state, actorRef }
+    },
+    (
+      get,
+      set,
+      action:
+        | EventFromLogic<TMachine>
+        | ({ type: string } & Record<string, unknown>)
+    ) => {
+      const actor = get(actorOrchestratorAtom)
+      actor.send(action as EventFromLogic<TMachine>)
+    }
+  )
+
+  return actorStateAtom
+}
+
+/**
+ * 
+: WritableAtom<
+  // Interpreter<TMachine, EventFromLogic<TMachine>>,
+  SnapshotFrom<TMachine>,
+  EventFromLogic<TMachine> | AnyActorBehavior,
+  void
+>
+ */

--- a/src/atom-with-actor.ts
+++ b/src/atom-with-actor.ts
@@ -1,4 +1,4 @@
-import { type Getter, atom } from 'jotai'
+import { type Getter, type WritableAtom, atom } from 'jotai'
 import {
   type AnyStateMachine,
   type EventFromLogic,
@@ -112,13 +112,7 @@ export function atomWithActor<TMachine extends AnyStateMachine>(
       const actorRef = get(actorOrchestratorAtom)
       return { state, actorRef }
     },
-    (
-      get,
-      set,
-      action:
-        | EventFromLogic<TMachine>
-        | ({ type: string } & Record<string, unknown>)
-    ) => {
+    (get, set, action: EventFromLogic<TMachine>) => {
       const actor = get(actorOrchestratorAtom)
       actor.send(action as EventFromLogic<TMachine>)
     }

--- a/src/empty-actor.ts
+++ b/src/empty-actor.ts
@@ -1,0 +1,11 @@
+import {
+  type ActorRef,
+  type AnyEventObject,
+  fromTransition,
+  interpret,
+} from 'xstate'
+
+const emptyLogic = fromTransition((_) => undefined, undefined)
+export function createEmptyActor(): ActorRef<AnyEventObject, undefined> {
+  return interpret(emptyLogic)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export { atomWithMachine, RESTART } from './atomWithMachine'
+export * from './atom-with-actor'
+export * from './atom-with-actor-subscription'

--- a/src/jotai-xstate.types.ts
+++ b/src/jotai-xstate.types.ts
@@ -1,0 +1,72 @@
+import type {
+  AnyActorLogic,
+  AnyActorRef,
+  AnyStateMachine,
+  AreAllImplementationsAssumedToBeProvided,
+  EventObject,
+  InternalMachineImplementations,
+  InterpreterOptions,
+  MachineContext,
+  MarkAllImplementationsAsProvided,
+  StateConfig,
+  StateMachine,
+} from 'xstate';
+
+export interface MachineAtomOptions<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
+  /**
+   * If provided, will be merged with machine's `context`.
+   */
+  context?: Partial<TContext>;
+  /**
+   * The state to rehydrate the machine to. The machine will
+   * start at this state instead of its `initialState`.
+   */
+  state?: StateConfig<TContext, TEvent>;
+}
+
+export type Options<TMachine extends AnyStateMachine> =
+  AreAllImplementationsAssumedToBeProvided<
+    TMachine['__TResolvedTypesMeta']
+  > extends false
+    ? InterpreterOptions<AnyActorLogic> &
+        MachineAtomOptions<TMachine['__TContext'], TMachine['__TEvent']> &
+        InternalMachineImplementations<
+          TMachine['__TContext'],
+          TMachine['__TEvent'],
+          TMachine['__TResolvedTypesMeta'],
+          true
+        >
+    : InterpreterOptions<AnyActorLogic> &
+        MachineAtomOptions<TMachine['__TContext'], TMachine['__TEvent']> &
+        InternalMachineImplementations<
+          TMachine['__TContext'],
+          TMachine['__TEvent'],
+          TMachine['__TResolvedTypesMeta']
+        >;
+
+export type MaybeParam<T> = T extends (v: infer V) => unknown ? V : never;
+
+export type SendEvent = Parameters<AnyActorRef['send']>[0];
+
+// Taken from https://github.com/statelyai/xstate/blob/xstate%405.0.0-beta.13/packages/xstate-react/src/createActorContext.ts
+type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
+  TMachine extends StateMachine<
+    infer TContext,
+    infer TEvent,
+    infer TAction,
+    infer TActorMap,
+    infer TResolvedTypesMeta
+  >
+    ? StateMachine<
+        TContext,
+        TEvent,
+        TAction,
+        TActorMap,
+        AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
+          ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
+          : TResolvedTypesMeta
+      >
+    : never;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+import { type Getter } from 'jotai'
+
+export const isGetter = <T>(
+  v: T | ((get: Getter) => T)
+): v is (get: Getter) => T => typeof v === 'function'
+
+export function defaultCompare<T>(a: T, b: T) {
+  return a === b
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7735,10 +7735,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xstate@^4.35.4:
-  version "4.35.4"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.35.4.tgz#87b2a45b6c7e84d820f56378408c6531ca5c4662"
-  integrity sha512-mqRBYHhljP1xIItI4xnSQNHEv6CKslSM1cOGmvhmxeoDPAZgNbhSUYAL5N6DZIxRfpYY+M+bSm3mUFHD63iuvg==
+xstate@^5.0.0-beta.14:
+  version "5.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.0.0-beta.14.tgz#2ca14b8bd299294077621a6e0b95cc7fac10db00"
+  integrity sha512-TIo+7AN/P4BRwugiiZnrNugv2pG55/hYbswECy6me9JL2mSYnpMg+nMF6piVKjd5C4m4RB8+/sGJuMV0XfF23Q==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Here is something that is "working" for me using XState 5 beta. 

My main issue is that the `send` method seems to infer `never` as the only event type from the machine. I don't think the inference is working fully with v5, as XState React currently casts to `any` 

I also exposed both the Actor reference and the subscribed state. This is so that you can use the ref and not cause re-renders or use it to subscribe to child actors. Here is an example.

```ts
export type AuthMachineActor = Interpreter<
  typeof authStateMachine,
  EventFromLogic<typeof authStateMachine>
>;

export const authMachineAtom = atomWithSubscription<typeof authStateMachine>(
  (get) => get(appMachineAtom).actorRef.system.get(
    AUTH_STATE_ID
  ) as AuthMachineActor
);
```

I'm still doing too much typecasting. And the above assumes that the actor with `AUTH_STATE_ID` as the `systemId` has been invoked/spawned in your main appMachine. 

Looking at how state works, you can probably get away with something crazy like this.

```ts
export const authMachineAtom = atomWithActor(authStateMachine, get => ({
    id: AUTH_STATE_ID,
    systemId: AUTH_STATE_ID,
    parent: get(appMachineAtom).actorRef
  })
);
```

In the second example, I'm feeding the parent into the `interpret` command. This is what the state does internally when invoking an actor. It works ok too. You could use this to "lazy load" an actor into a state machine. 

I also didn't put in `RESET`. I wanted to solve the send event type inference first. 